### PR TITLE
Control for multiple choice display language

### DIFF
--- a/EMQ/Client/Components/PlayerPreferencesComponent.razor
+++ b/EMQ/Client/Components/PlayerPreferencesComponent.razor
@@ -49,6 +49,10 @@
                                     <label for="WantsEnglish">Prefer English titles when available</label>
                                     <br/>
 
+                                    <InputCheckbox id="WantsOriginalTitle" class="form-check-input" @bind-Value="ClientState.Preferences.WantsOriginalTitle" style="margin: 5px"></InputCheckbox>
+                                    <label for="WantsOriginalTitle">Prefer original title for multiple choice options</label>
+                                    <br/>
+
                                     <InputCheckbox id="RestartSongsOnResultsPhase" class="form-check-input" @bind-Value="ClientState.Preferences.RestartSongsOnResultsPhase" style="margin: 5px"></InputCheckbox>
                                     <label for="RestartSongsOnResultsPhase">Restart songs on Results Phase</label>
                                     <br/>

--- a/EMQ/Client/Pages/QuizPage.razor
+++ b/EMQ/Client/Pages/QuizPage.razor
@@ -456,7 +456,7 @@
                 {
                     foreach (var title in current)
                     {
-                        string displayTitle = ClientState.Preferences.WantsEnglish ? title.LatinTitle : (title.NonLatinTitle ?? title.LatinTitle);
+                        string displayTitle = ClientState.Preferences.WantsOriginalTitle ? (title.NonLatinTitle ?? title.LatinTitle) : title.LatinTitle;
                         bool selected = PageState.Guess?.Dict[GuessKind.Mst] == title.LatinTitle;
                         <div class="MultipleChoiceOption" title="@(title.ToString())"
                              @onclick="@(async () => { if (!IsSpectator) await SetGuess(new PlayerGuess { Dict = { [GuessKind.Mst] = title.LatinTitle } }); })"

--- a/EMQ/Client/Pages/QuizPage.razor
+++ b/EMQ/Client/Pages/QuizPage.razor
@@ -456,6 +456,7 @@
                 {
                     foreach (var title in current)
                     {
+                        string displayTitle = ClientState.Preferences.WantsEnglish ? title.LatinTitle : (title.NonLatinTitle ?? title.LatinTitle);
                         bool selected = PageState.Guess?.Dict[GuessKind.Mst] == title.LatinTitle;
                         <div class="MultipleChoiceOption" title="@(title.ToString())"
                              @onclick="@(async () => { if (!IsSpectator) await SetGuess(new PlayerGuess { Dict = { [GuessKind.Mst] = title.LatinTitle } }); })"
@@ -479,7 +480,7 @@ text-align: center;
 /*align-items: center;*/
 word-wrap: break-word;
 ">
-                            @title.LatinTitle
+                            @displayTitle
                         </div>
                     }
                 }

--- a/EMQ/Shared/Quiz/Entities/Concrete/Player.cs
+++ b/EMQ/Shared/Quiz/Entities/Concrete/Player.cs
@@ -174,6 +174,9 @@ public class PlayerPreferences
     public bool WantsEnglish { get; set; } = false;
 
     [Required]
+    public bool WantsOriginalTitle { get; set; } = false;
+
+    [Required]
     public bool ShowVndbCovers { get; set; } = true;
 
     [Required]


### PR DESCRIPTION
I'm looking for some way to change the display language of the multiple choice options. Are you okay with reusing the "Prefer English titles when available" option or do you think it's better to have another option since Japanese romaji is not really English?